### PR TITLE
State Machine and Cruise Control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ mbed-os
 BUILD
 
 PID
+embedded/mbed-os

--- a/.mbedignore
+++ b/.mbedignore
@@ -1,1 +1,2 @@
 embedded/testRunner.cpp
+embedded/mbed-os/*

--- a/include/analog.h
+++ b/include/analog.h
@@ -1,6 +1,7 @@
 #ifndef __ANALOG_H__
 #define __ANALOG_H__
 
+#include "mutexless_analog.h"
 #include "telemetry.h"
 
 // defining the reference voltage for analog inputs

--- a/include/analog.h
+++ b/include/analog.h
@@ -6,6 +6,9 @@
 // defining the reference voltage for analog inputs
 #define refrence_voltage 3.3
 
+#define PEDAL_ON_THRESHOLD 0.25 // 1.5V/5V
+#define PEDAL_RANGE 0.417  // 0.86 - 0.3, where 0.86 = 4.33V/5V is the max
+
 // read all the analog inputs
 void readAnalog();
 

--- a/include/canmcc.h
+++ b/include/canmcc.h
@@ -1,0 +1,27 @@
+#ifndef __CAN_MCC_H__
+#define __CAN_MCC_H__
+
+#include "canmanager.h"
+#include "telemetry.h"
+#include "motor_control.h"
+
+
+#define MCC_CAN_TICKER_INTERVAL 10000us
+
+
+/*
+    Class managing CAN bus for MCC
+    See CANManager class for usage documentation
+*/
+class CANMCC : public CANManager {
+    public:
+        CANMCC(PinName rd, PinName td, MCCState* stateMachine, int frequency = DEFAULT_CAN_FREQ);
+        void readHandler(int messageID, SharedPtr<unsigned char> data, int length);
+        void send_mcc_data();
+
+    private:
+        MCCState* stateMachine;
+        void send_helper(int messageID, void *data, int length);
+};
+
+#endif

--- a/include/motor_control.h
+++ b/include/motor_control.h
@@ -5,9 +5,29 @@
 #include "telemetry.h"
 #include "digital.h"
 #include "analog.h"
+#include "PID.h"
 
 #define MIN_MOVING_SPEED 3.0        // speed threshold for idle state
 
+
+// PID macros
+#define POWER_P_PARAM 0.0
+#define POWER_I_PARAM 0.0
+#define POWER_D_PARAM 0.0
+#define SPEED_P_PARAM 1.0/720
+#define SPEED_I_PARAM 0.0
+#define SPEED_D_PARAM 0.0
+
+// limits for power and speed PIDs.
+#define MIN_POWER 0.0
+#define MAX_POWER 1.0
+#define MIN_RPM 0.0
+#define MAX_RPM 48.0
+
+// limits for outputs of PID
+// is 0.0 to 1.0 due to how AnalogOut pins work.
+#define MIN_OUT 0.0
+#define MAX_OUT 1.0
 
 enum class MCCStates{
     OFF,
@@ -15,7 +35,8 @@ enum class MCCStates{
     IDLE,
     FORWARD,
     REVERSE,
-    CRUISE
+    CRUISE_POWER,
+    CRUISE_SPEED
 };
 
 class MCCState {
@@ -31,6 +52,12 @@ class MCCState {
         MCCState(std::chrono::microseconds ticker_delay);
         ~MCCState();
         MCCStates get_state();
+
+        // cruise control variables
+        float target_speed;
+        float target_power;
+        PID *curr_PID;
+        PID power_PID, speed_PID;
 };
 
 #endif

--- a/include/telemetry.h
+++ b/include/telemetry.h
@@ -39,4 +39,7 @@ extern volatile float regenerativeBraking;
 
 extern volatile float motorSpeedSetpoint;
 
+// Serial signals
+extern volatile bool parkBrake;
+
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -4,17 +4,24 @@
 #include "analog.h"
 #include "speed.h"
 #include "motor_control.h"
+#include "canmcc.h"
 
-#define SPEED_CALC_INTERVAL 10ms
-#define ANALOG_CALC_INTERVAL 10000us
-#define DIGITAL_CALC_INTERVAL 10000us
+#define SPEED_CALC_INTERVAL 25ms
+#define ANALOG_CALC_INTERVAL 50000us
+#define DIGITAL_CALC_INTERVAL 50000us
 
 // time between checking for transitions in state machine in us
-#define SM_TRANSITION_INTERVAL 1000000us
+#define SM_TRANSITION_INTERVAL 500000us
+
+#define CAN_RX PA_11
+#define CAN_TX PA_12
 
 
 int main()
 {
+    // Set terminal to fast print
+    BufferedSerial terminal(USBTX, USBRX, 115200);
+
     // read RPM and MPH every 0.01 second
     startSpeedCalculation(SPEED_CALC_INTERVAL);
 
@@ -27,7 +34,63 @@ int main()
     // initialize state machine
     MCCState state_machine(SM_TRANSITION_INTERVAL);
 
-    while (true) {
+    CANMCC canBus(CAN_RX, CAN_TX, &state_machine);
 
+
+    while(true){
+        printf("\e[1;1H\e[2J");
+        //state printout
+        switch (state_machine.get_state()) {
+            case MCCStates::OFF :
+                printf("State: OFF\n");
+                break;
+            case MCCStates::PARK :
+                printf("State: PARK\n");
+                break;
+            case MCCStates::IDLE :
+                printf("State: IDLE\n");
+                break;
+            case MCCStates::FORWARD :
+                printf("State: FORWARD\n");
+                break;
+            case MCCStates::REVERSE :
+                printf("State: REVERSE\n");
+                break;
+            case MCCStates::CRUISE_POWER :
+                printf("State: CRUISE\n");
+                break;
+            case MCCStates::CRUISE_SPEED:
+                printf("State: CRUISE\n");
+                break;
+            default:
+                printf("Unknown state?\n");
+                break;
+        }
+
+        // inputs
+        printf("INPUTS-------------------------------\n");
+        printf("Motor Power: %s\n", digital_data.motorPower ? "On" : "Off");
+        printf("Forward and Reverse: %s\n", digital_data.forwardAndReverse ? "Forward" : "Reverse");
+        printf("RPM: %f\n", rpm);
+        printf("MPH: %f\n", mph);
+        printf("Brake Status: %f\n", brakeStatus);
+        printf("acceleratorPedal: %f\n", acceleratorPedal);
+        switch(cruzMode) {
+            case CRUZ_MODE::OFF :
+                printf("cruzMode: OFF\n");
+                break;
+            case CRUZ_MODE::POWER :
+                printf("cruzMode: POWER\n");
+                break;
+            case CRUZ_MODE::SPEED :
+                printf("cruzMode: SPEED\n");
+                break;
+        }
+        printf("motorSpeedSetpoint: %f\n", motorSpeedSetpoint);
+        printf("parkingBrake: %s\n", parkBrake ? "On" : "Off");
+        canBus.send_mcc_data();
+        canBus.doRead(1000ms);
+
+        wait_us(1000000);
     }
 }

--- a/main.cpp
+++ b/main.cpp
@@ -89,8 +89,8 @@ int main()
         printf("motorSpeedSetpoint: %f\n", motorSpeedSetpoint);
         printf("parkingBrake: %s\n", parkBrake ? "On" : "Off");
         canBus.send_mcc_data();
-        canBus.doRead(1000ms);
+        canBus.doRead(10ms);
 
-        wait_us(1000000);
+        //wait_us(1000000);
     }
 }

--- a/main.cpp
+++ b/main.cpp
@@ -89,7 +89,7 @@ int main()
         printf("motorSpeedSetpoint: %f\n", motorSpeedSetpoint);
         printf("parkingBrake: %s\n", parkBrake ? "On" : "Off");
         canBus.send_mcc_data();
-        canBus.doRead(10ms);
+        canBus.runQueue(10ms);
 
         //wait_us(1000000);
     }

--- a/src/analog.cpp
+++ b/src/analog.cpp
@@ -25,7 +25,8 @@ AnalogInMutexless brakeStatusPin(A1);
 AnalogInMutexless regenerativeBrakingPin(A4);
 
 // assign analog outputs to the correct pins
-AnalogOutMutexless motorAccelerationOutput(A3);
+//AnalogOutMutexless motorAccelerationOutput(A3);
+PwmOut motorAccelerationOutput(A3);
 
 // initialize the analog inputs' readings
 volatile float acceleratorPedal = 0;
@@ -34,8 +35,15 @@ volatile float regenerativeBraking = 0;
 
 
 // read accelerator pedal input
-void readAcceleratorPedal(){ 
-    acceleratorPedal = acceleratorPedalPin.read_voltage();
+void readAcceleratorPedal(){
+    float value = (acceleratorPedalPin.read() - PEDAL_ON_THRESHOLD) / PEDAL_RANGE;
+    if (value < 0) {
+        acceleratorPedal = 0;
+    } else if (value > 1) {
+        acceleratorPedal = 1;
+    } else {
+        acceleratorPedal = value;
+    }    
 }
 
 // read brake status input
@@ -66,5 +74,5 @@ void initAnalog(std::chrono::microseconds readSignalPeriod) {
 
 // set the value of the acc_out pin
 void setAccOut(float acc) {
-    motorAccelerationOutput.write(acc);
+    motorAccelerationOutput.write(1-acc);
 }

--- a/src/analog.cpp
+++ b/src/analog.cpp
@@ -3,22 +3,6 @@
 // initialize Ticker to setup a recurring interrupt to repeatedly call the function at a specified rate
 Ticker readAnalogDelay;
 
-// Disable mutex usage of analog read for interrupt polling
-// because mutex cannot be used in ISR
-class AnalogInMutexless : public AnalogIn {
-public:
-    AnalogInMutexless(PinName pin) : AnalogIn(pin) { }
-    virtual void lock() { }
-    virtual void unlock() { }
-};
-
-class AnalogOutMutexless : public AnalogOut {
-    public:
-        AnalogOutMutexless(PinName pin) : AnalogOut(pin) { }
-        virtual void lock() { }
-        virtual void unlock() { }
-};
-
 // assign analog inputs to the correct pins
 AnalogInMutexless acceleratorPedalPin(A6);
 AnalogInMutexless brakeStatusPin(A1);

--- a/src/canmcc.cpp
+++ b/src/canmcc.cpp
@@ -20,24 +20,24 @@ void CANMCC::readHandler(int messageID, SharedPtr<unsigned char> data, int lengt
 
 void CANMCC::send_mcc_data() {
     // Digital signals
-    this->sendMessage(0x200, (void*)&digital_data, 1);
-    this->sendMessage(0x201, (void*)&cruzMode, 1);
+    this->sendMessage(0x200, (void*)&digital_data, 1, 1ms);
+    this->sendMessage(0x201, (void*)&cruzMode, 1, 1ms);
     char charHelper = (char)this->stateMachine->get_state();
-    this->sendMessage(0x202, &charHelper, 1);
+    this->sendMessage(0x202, &charHelper, 1, 1ms);
     
-    wait_us(8000);
+    //wait_us(8000);
     // send floats
     float float_helper = acceleratorPedal;
-    this->sendMessage(0x203, &float_helper, 4);
+    this->sendMessage(0x203, &float_helper, 4, 1ms);
     float_helper = brakeStatus;
-    this->sendMessage(0x204, &float_helper, 4);
+    this->sendMessage(0x204, &float_helper, 4, 1ms);
     float_helper = regenerativeBraking;
-    this->sendMessage(0x205, &float_helper, 4);
-    wait_us(8000);
+    this->sendMessage(0x205, &float_helper, 4, 1ms);
+    //wait_us(8000);
     float_helper = motorSpeedSetpoint;
-    this->sendMessage(0x206, &float_helper, 4);
+    this->sendMessage(0x206, &float_helper, 4, 1ms);
     float_helper = rpm;
-    this->sendMessage(0x207, &float_helper, 4);
+    this->sendMessage(0x207, &float_helper, 4, 1ms);
     float_helper = mph;
-    this->sendMessage(0x208, &float_helper, 4);
+    this->sendMessage(0x208, &float_helper, 4, 1ms);
 }

--- a/src/canmcc.cpp
+++ b/src/canmcc.cpp
@@ -1,0 +1,43 @@
+#include "canmcc.h"
+
+volatile bool parkBrake = false;
+
+CANMCC::CANMCC(PinName rd, PinName td, MCCState* stateMachine, int frequency): CANManager(rd, td, frequency) {
+    this->stateMachine = stateMachine;
+}
+
+void CANMCC::readHandler(int messageID, SharedPtr<unsigned char> data, int length) {
+    // Variable to track number of received messages
+    static unsigned long messageCount = 0;
+    messageCount++;
+
+    // Park brake from main
+    if (messageID == 0x100) {
+        parkBrake = *data;
+    }
+}
+
+
+void CANMCC::send_mcc_data() {
+    // Digital signals
+    this->sendMessage(0x200, (void*)&digital_data, 1);
+    this->sendMessage(0x201, (void*)&cruzMode, 1);
+    char charHelper = (char)this->stateMachine->get_state();
+    this->sendMessage(0x202, &charHelper, 1);
+    
+    wait_us(8000);
+    // send floats
+    float float_helper = acceleratorPedal;
+    this->sendMessage(0x203, &float_helper, 4);
+    float_helper = brakeStatus;
+    this->sendMessage(0x204, &float_helper, 4);
+    float_helper = regenerativeBraking;
+    this->sendMessage(0x205, &float_helper, 4);
+    wait_us(8000);
+    float_helper = motorSpeedSetpoint;
+    this->sendMessage(0x206, &float_helper, 4);
+    float_helper = rpm;
+    this->sendMessage(0x207, &float_helper, 4);
+    float_helper = mph;
+    this->sendMessage(0x208, &float_helper, 4);
+}

--- a/src/speed.cpp
+++ b/src/speed.cpp
@@ -12,7 +12,7 @@ volatile float mph = 0;
 // Track past pulses for precision
 static vector<unsigned int> previousPulses;
 // How often speed computation happens
-static std::chrono::milliseconds speedInterval = 0ms;
+static unsigned int speedInterval = 0;
 // Number of PWM pulses since last calculation
 static volatile unsigned int speedPulses = 0;
 
@@ -40,16 +40,18 @@ void calculateSpeed()
 {
     // Variable to track array update position
     static int calculationCounter = 0;
+    static unsigned int totalTicks = 0;
 
     // Replace the oldest remembered pulse count in the vector with a new one
+    totalTicks = totalTicks - previousPulses.at(calculationCounter % previousPulses.size()) + speedPulses;
     previousPulses.at(calculationCounter % previousPulses.size()) = speedPulses;
     speedPulses = 0;
     calculationCounter ++;
 
     // Calculate rpm based the total number of pulses in the previousPulses vector
-    float revolutions = sum(previousPulses) / 48.0f;
-    rpm = revolutions / (speedInterval.count() * previousPulses.size() / 1000.0f / 60.0f);
-    mph = rpm * WHEEL_CIRCUMFERENCE / 12.0f / 5280.0f * 60;
+    float revolutions = totalTicks * 0.020833333; // 1 / 48
+    rpm = revolutions / (speedInterval * previousPulses.size() * 0.0000166666666); // 1 / 1000 / 60
+    mph = rpm * WHEEL_CIRCUMFERENCE * 0.00094696; // 1 / 12 / 5280 * 60
 
 
     /*
@@ -65,7 +67,7 @@ void calculateSpeed()
 // Starts repeating rpm calculation every interval milliseconds
 void startSpeedCalculation(std::chrono::milliseconds interval)
 {
-    speedInterval = interval;
+    speedInterval = interval.count();
 
     // Attach the address of the increment function to the rising edge of the speed pin
     speedPin.rise(&increment);
@@ -74,5 +76,5 @@ void startSpeedCalculation(std::chrono::milliseconds interval)
     rpmTicker.attach(calculateSpeed, interval);
 
     // Set size of previousPulses such that we remember appox 1250 ms of previous pulses
-    previousPulses.resize(1250 / interval.count(), 0);
+    previousPulses.resize(1250 / speedInterval, 0);
 }


### PR DESCRIPTION
- Adds `canmcc.c`, a file that will send the MCC's CAN messages.
- Adds macros in `analog.h` for the pedal voltage threshold and range (actual tested values)
- `main.cpp`: changed the rate at which PWM is calculated, from 10ms to 25ms. (There are runtime errors when it's 10ms)
- `analog.cpp`: changed motorAccelerationOutput pin from an `AnalogOut` to a `PwmOut`. Not sure why it's `1-acc` in `motorAccelerationOutput.write(1-acc);` on line 77.
- `motor_control.cpp`: fixed transition from PARK to IDLE state
- `speed.cpp`: various optimizations, such as adding new tick value and removing oldest tick value instead of summing up all tick values in the vector every time we want to do an average. Also, replaced some math with precalculated constants. NOTE: might want to do `calculationCounter = (calculationCounter+1) % previousPulses.size();` so calculationCounter doesn't overflow.