### PR TITLE
FW-210: Regen Brake Enable Button

### DIFF
--- a/include/telemetry.h
+++ b/include/telemetry.h
@@ -113,11 +113,14 @@ extern volatile float mph;
 
 extern volatile float acceleratorPedal;
 extern volatile float regenerativeBraking;
+extern volatile bool regenBrakeEnable;
 
 extern volatile float motorSpeedSetpoint;
 
 extern volatile bool parkBrake;
 
 extern volatile float speed_pid_compute;
+
+
 
 #endif

--- a/src/analog.cpp
+++ b/src/analog.cpp
@@ -46,9 +46,13 @@ void setAccOut(float acc) {
     motorAccelerationOutput.write(acc);
 }
 
-// set the value of the regenerative brake output pin
+// set the value of the regenerative brake output pin IF regen braking is turned on
 void setRegenBrakeOut(float value) {
-    regenerativeBrakingOutputPin.write(value);
+    if (regenBrakeEnable) {
+        regenerativeBrakingOutputPin.write(value);
+    } else {
+        regenerativeBrakingOutputPin.write(0);
+    }
 }
 
 // read all analog input

--- a/src/digital.cpp
+++ b/src/digital.cpp
@@ -13,6 +13,8 @@ DigitalIn motorPowerPin(PA_0);
 DigitalIn directionInputPin(PA_7);
 DigitalIn ecoModePin(PA_5);
 DigitalIn brakeStatusPin(PA_8);
+// TODO: change the pin to the correct one, it's currently just an arbitrary unused pin
+DigitalIn regenBrakeEnablePin(PF_0); 
 
 // assign digital output to the correct pins
 DigitalOut directionOutputPin(PA_3);
@@ -25,9 +27,12 @@ volatile CRUZ_MODE cruzMode = CRUZ_MODE::OFF;
 volatile float motorSpeedSetpoint = 0;
 
 volatile bool parkBrake = true;
+volatile bool regenBrakeEnable = false;
 
 bool pastSetCruz = false;
 bool pastResetCruz = false;
+
+
 
 
 void readCruiseControl() {
@@ -105,6 +110,8 @@ void readBrakeStatus() { digital_data.brakeStatus = brakeStatusPin.read(); }
 // read parking brake status
 void readParkBrake() { parkBrake = parkBrakePin.read(); }
 
+void readRegenBrakeEnable() { regenBrakeEnable = regenBrakeEnablePin.read(); }
+
 // read all the digital inputs
 void readDigital() {
   readCruiseControl();
@@ -113,6 +120,7 @@ void readDigital() {
   readEcoMode();
   readBrakeStatus();
   readParkBrake();
+  readRegenBrakeEnable();
 }
 
 // Set up polling of digital IO at specified rate


### PR DESCRIPTION
Adds a `regenBrakeEnablePin` that is currently mapped to `PF_0` (an arbitrary unused pin). This pin will read the button used to enable regen braking. 

When the pin is 0, the regen brake output will be set to 0.
When the pin is 1, the regen brake output will be set based on the regen brake input. 