### PR TITLE
Add Brake Sensor pin to turn on Brake LED, add optimizations

### DIFF
--- a/include/speed.h
+++ b/include/speed.h
@@ -6,7 +6,7 @@
 /*
     Starts speed (RPM and MPH) calculations at specified interval
 */
-void startSpeedCalculation(std::chrono::milliseconds interval);
+void startSpeedCalculation();
 
 
 #endif // __SPEED_H__

--- a/include/telemetry.h
+++ b/include/telemetry.h
@@ -62,6 +62,8 @@ enum class MCCStates : uint8_t {
 #define REGEN_ON_THRESHOLD 0 // TODO set actual value
 #define REGEN_RANGE 1 // TODO set actual value
 
+#define BRAKE_SENSOR_THRESHOLD 0.14 // 0.7/5
+
 //////////////////////////
 // motor_error.h macros //
 //////////////////////////
@@ -113,6 +115,7 @@ extern volatile float mph;
 
 extern volatile float acceleratorPedal;
 extern volatile float regenerativeBraking;
+extern volatile float brakeSensor;
 
 extern volatile float motorSpeedSetpoint;
 

--- a/include/telemetry.h
+++ b/include/telemetry.h
@@ -54,6 +54,7 @@ enum class MCCStates : uint8_t {
 // analog.h macros //
 /////////////////////
 // defining the reference voltage for analog inputs
+// TODO: maybe this should be 5
 #define REFERENCE_VOLTAGE 3.3
 
 #define PEDAL_ON_THRESHOLD 0.25 // 1.5V/5V

--- a/main.cpp
+++ b/main.cpp
@@ -7,13 +7,11 @@
 #include "speed.h"
 #include "telemetry.h"
 
-
-#define SPEED_CALC_INTERVAL 50ms
-#define ANALOG_CALC_INTERVAL 10000us
-#define DIGITAL_CALC_INTERVAL 10000us
+#define ANALOG_CALC_INTERVAL 50000us
+#define DIGITAL_CALC_INTERVAL 50000us
 
 // time between checking for transitions in state machine in us
-#define SM_TRANSITION_INTERVAL 500000us
+#define SM_TRANSITION_INTERVAL 50000us
 
 #define CAN_RX PA_11
 #define CAN_TX PA_12
@@ -25,7 +23,7 @@ int main()
     BufferedSerial terminal(USBTX, USBRX, 115200);
 
     // read RPM and MPH every 0.01 second
-    startSpeedCalculation(SPEED_CALC_INTERVAL);
+    startSpeedCalculation();
 
     // read all analog inputs every 0.01 second
     initAnalog(ANALOG_CALC_INTERVAL);
@@ -37,7 +35,7 @@ int main()
     MCCState state_machine(SM_TRANSITION_INTERVAL);
 
     // error LED reading
-    startErrorInterpretation();
+    //startErrorInterpretation();
 
     CANMCC canBus(CAN_RX, CAN_TX);
 
@@ -101,6 +99,6 @@ int main()
         printf("speed_pid_compute: %f\n", speed_pid_compute);
 
         canBus.send_mcc_data();
-        canBus.runQueue(1000ms);
+        canBus.runQueue(100ms);
     }
 }

--- a/src/analog.cpp
+++ b/src/analog.cpp
@@ -17,50 +17,34 @@ volatile float acceleratorPedal = 0;
 volatile float regenerativeBraking = 0;
 volatile float brakeSensor = 0;
 
-// read accelerator pedal input
-void readAcceleratorPedal(){
-    float value = (acceleratorPedalPin.read() - PEDAL_ON_THRESHOLD) / PEDAL_RANGE;
-    if (value < 0) {
-        acceleratorPedal = 0;
-    } else if (value > 1) {
-        acceleratorPedal = 1;
-    } else {
-        acceleratorPedal = value;
-    }    
-}
-
-// read regenative braking input
-void readRegenerativeBrakingInput(){
-    float value = (regenerativeBrakingInputPin.read() - REGEN_ON_THRESHOLD) / REGEN_RANGE;
-    if (value < 0) {
-        regenerativeBraking = 0;
-    } else if (value > 1) {
-        regenerativeBraking = 1;
-    } else {
-        regenerativeBraking = value;
-    }  
-}
-
-void readBrakeSensor() {
-    brakeSensor = brakeSensorPin.read();
-}
-
 // set the value of the acc_out pin
 void setAccOut(float acc) {
     motorAccelerationOutput.write(acc);
 }
 
-// set the value of the regenerative brake output pin
-void setRegenBrakeOut(float value) {
-    regenerativeBrakingOutputPin.write(value);
-}
-
 // read all analog input
 void readAnalog(){
-    readAcceleratorPedal();
-    readRegenerativeBrakingInput();
-    readBrakeSensor();
-    setRegenBrakeOut(0);
+    // read Accelerator Input
+    acceleratorPedal = (acceleratorPedalPin.read() - PEDAL_ON_THRESHOLD) / PEDAL_RANGE;
+    if (acceleratorPedal < 0) {
+        acceleratorPedal = 0;
+    } else if (acceleratorPedal > 1) {
+        acceleratorPedal = 1;
+    } 
+
+    // read regen brake input
+    regenerativeBraking = (regenerativeBrakingInputPin.read() - REGEN_ON_THRESHOLD) / REGEN_RANGE;
+    if (regenerativeBraking < 0) {
+        regenerativeBraking = 0;
+    } else if (regenerativeBraking > 1) {
+        regenerativeBraking = 1;
+    } 
+
+    // read brake sensor
+    brakeSensor = brakeSensorPin.read();
+
+    // TODO: update this when regen braking is on the car
+    regenerativeBrakingOutputPin.write(0);
 }
 
 // Set up polling of analog IO at specified rate

--- a/src/analog.cpp
+++ b/src/analog.cpp
@@ -6,16 +6,16 @@ Ticker readAnalogDelay;
 // assign analog inputs to the correct pins
 AnalogInMutexless acceleratorPedalPin(PB_0);
 AnalogInMutexless regenerativeBrakingInputPin(PB_1);
+AnalogInMutexless brakeSensorPin(PA_7);
 
 // assign analog outputs to the correct pins
-//AnalogOutMutexless motorAccelerationOutput(A3);
 AnalogOutMutexless motorAccelerationOutput(PA_4);
 AnalogOutMutexless regenerativeBrakingOutputPin(PA_6);
 
 // initialize the analog inputs' readings
 volatile float acceleratorPedal = 0;
 volatile float regenerativeBraking = 0;
-
+volatile float brakeSensor = 0;
 
 // read accelerator pedal input
 void readAcceleratorPedal(){
@@ -41,6 +41,10 @@ void readRegenerativeBrakingInput(){
     }  
 }
 
+void readBrakeSensor() {
+    brakeSensor = brakeSensorPin.read();
+}
+
 // set the value of the acc_out pin
 void setAccOut(float acc) {
     motorAccelerationOutput.write(acc);
@@ -55,6 +59,7 @@ void setRegenBrakeOut(float value) {
 void readAnalog(){
     readAcceleratorPedal();
     readRegenerativeBrakingInput();
+    readBrakeSensor();
     setRegenBrakeOut(0);
 }
 
@@ -62,6 +67,7 @@ void readAnalog(){
 void initAnalog(std::chrono::microseconds readSignalPeriod) {
     acceleratorPedalPin.set_reference_voltage(REFERENCE_VOLTAGE);
     regenerativeBrakingInputPin.set_reference_voltage(REFERENCE_VOLTAGE);
+    brakeSensorPin.set_reference_voltage(REFERENCE_VOLTAGE);
 
     readAnalogDelay.attach(readAnalog, readSignalPeriod);
 }

--- a/src/can_mcc.cpp
+++ b/src/can_mcc.cpp
@@ -1,6 +1,8 @@
 #include "can_mcc.h"
 
-CANMCC::CANMCC(PinName rd, PinName td, int frequency): CANManager(rd, td, frequency) {}
+CANMCC::CANMCC(PinName rd, PinName td, int frequency): CANManager(rd, td, frequency) {
+    filter(0, 0xFFF);
+}
 
 void CANMCC::readHandler(int messageID, SharedPtr<unsigned char> data, int length) {
 

--- a/src/digital.cpp
+++ b/src/digital.cpp
@@ -36,7 +36,7 @@ void readCruiseControl() {
   bool setCruz = setCruiseControlPin.read();
 
   // read reset cruise control input
-  // decrment
+  // decrement
   bool resetCruz = resetCruiseControlPin.read();
 
   // read cruise speed mode input
@@ -90,29 +90,14 @@ void readCruiseControl() {
 }
 
 
-// read motor power input
-void readMotorPower() { digital_data.motorPower = motorPowerPin.read(); }
-
-// read forward and reverse input
-void readForwardAndReverse() { digital_data.forwardAndReverse = directionInputPin.read(); }
-
-// read eco mode input
-void readEcoMode() { digital_data.ecoMode = ecoModePin.read(); }
-
-// read hand/foot brake status
-void readBrakeStatus() { digital_data.brakeStatus = brakeStatusPin.read(); }
-
-// read parking brake status
-void readParkBrake() { parkBrake = parkBrakePin.read(); }
-
 // read all the digital inputs
 void readDigital() {
   readCruiseControl();
-  readMotorPower();
-  readForwardAndReverse();
-  readEcoMode();
-  readBrakeStatus();
-  readParkBrake();
+  digital_data.motorPower = motorPowerPin.read();
+  digital_data.forwardAndReverse = directionInputPin.read(); 
+  digital_data.ecoMode = ecoModePin.read();
+  digital_data.brakeStatus = brakeStatusPin.read(); 
+  parkBrake = parkBrakePin.read();
 }
 
 // Set up polling of digital IO at specified rate

--- a/src/digital.cpp
+++ b/src/digital.cpp
@@ -10,7 +10,7 @@ DigitalIn resetCruiseControlPin(PB_5);
 DigitalIn parkBrakePin(PB_6); // used to be cruisePowerModePin
 DigitalIn cruiseSpeedModePin(PB_7);
 DigitalIn motorPowerPin(PA_0);
-DigitalIn directionInputPin(PA_7);
+DigitalIn directionInputPin(PA_9);
 DigitalIn ecoModePin(PA_5);
 DigitalIn brakeStatusPin(PA_8);
 

--- a/src/motor_control.cpp
+++ b/src/motor_control.cpp
@@ -144,8 +144,8 @@ void MCCState::transition() {
         setAccOut(0.0);
     }
 
-    // set brakeLED based on brakeStatus(foot and park brake) and regenerativeBraking
-    setBrakeLEDOutput(digital_data.brakeStatus || regenerativeBraking > REGEN_ON_THRESHOLD);
+    // set brakeLED based on analog brake sensor 
+    setBrakeLEDOutput(brakeSensor > BRAKE_SENSOR_THRESHOLD);
 
     mccState = this->state; // used to send state over CAN
 }

--- a/src/motor_control.cpp
+++ b/src/motor_control.cpp
@@ -55,8 +55,6 @@ void MCCState::transition() {
             }
             // OUTPUT: set acc_out pin based on acc_in from the pedal
             setAccOut(acceleratorPedal);
-            // OUTPUT: set fr_out to reverse
-            setDirectionOutput(REVERSE_VALUE);
             break;
 
         case MCCStates::FORWARD:
@@ -75,19 +73,13 @@ void MCCState::transition() {
             
             // OUTPUT: set acc_out pin based on acc_in from the pedal
             setAccOut(acceleratorPedal);
-            // OUTPUT: set fr_out to forward.
-            setDirectionOutput(FORWARD_VALUE);
             break;
 
         case MCCStates::CRUISE_POWER:
-            if (cruzMode == CRUZ_MODE::OFF) {
+            if (cruzMode != CRUZ_MODE::POWER) {
                 state = MCCStates::FORWARD;
                 break;
-            } else if (cruzMode == CRUZ_MODE::SPEED) {
-                curr_PID = &speed_PID;
-                state = MCCStates::CRUISE_SPEED;
-                break;
-            }
+            } 
             // TODO: not enough stuff for power right now (10/22)
             // get current motor power
             // set setPoint to target power
@@ -95,19 +87,14 @@ void MCCState::transition() {
             break;
 
         case MCCStates::CRUISE_SPEED:
-            if (cruzMode == CRUZ_MODE::OFF) {
+            if (cruzMode != CRUZ_MODE::SPEED) {
                 state = MCCStates::FORWARD;
                 break;
-            } else if (cruzMode == CRUZ_MODE::POWER) {
-                curr_PID = &power_PID;
-                state = MCCStates::CRUISE_POWER;
-                break;
-            }
+            } 
             // set current rpm for speed_PID
             speed_PID.setProcessValue(rpm);
             // set target for speed_PID
             speed_PID.setSetPoint(motorSpeedSetpoint);
-            // 
             speed_pid_compute = speed_PID.compute();
             // set accelerator 
             setAccOut(speed_pid_compute);

--- a/src/speed.cpp
+++ b/src/speed.cpp
@@ -3,7 +3,7 @@
 
 #define SPEED_CALC_INTERVAL 50ms
 #define SPEED_INTERVAL 50 
-#define ARRAY_SIZE 1250 / 50 // 1250ms/50ms
+#define ARRAY_SIZE 25 // 1250ms/50ms
 
 Ticker rpmTicker;
 


### PR DESCRIPTION
Change requested by @rvanells, which includes:
- `directionInputPin` changed from PA_7 to PA_9
- PA_7 pin now used for AnalogIn pin to read the mechanical Brake Sensor. 
- Added functionality in `motor_control.cpp` to turn on the Brake LED when the BrakeSensor input is above a certain threshold.

Note: the addition of a 3rd AnalogIn pin caused the program to have the 311 runtime error. This was fixed by building the MCC program via the RELEASE profile instead of the DEBUG profile like we usually do. However, since this is a band-aid fix, @Wigu701 suggested that we preemptively optimize our code to prepare for the event that we need to add more computationally intensive code in the future.

### Optimizations:
- in-lined a bunch of read pin functions in `analog.cpp` and `digital.cpp` since they were only called in the `readAnalog()` and `readDigital()` functions, and this saves us from having to do context switches for function calls. 
- removed error LED reading instantiation in `main.cpp` since it's not connected in hardware
- added a filter for CAN messages in the constructor of `can_mcc.cpp` 
- prevent transitions from CRUISE_POWER to CRUISE_SPEED state in `motor_control.cpp`

### `speed.cpp` optimizations:
- changed the vector for an array because we never resize the vector, we just set its size in initialization. 
- removed input `interval` from initialization function `startSpeedCalculation()` because we need to set the array size in `speed.cpp`, so it can't be a variable passed in from another function.
- added macros for array size, interval for rpm calculation. 
- removed O(n) `sum()` function that we no longer use (since we have O(1) solution)
- capped `calculationCounter` so that it never goes above the size of the array. This is to prevent overflow when the program runs for a long time. This also saves us one addition to calculate which index in the array we are considering.

NOTE: the `ARRAY_SIZE` macro caused us some issues because it was defined as `1250/50`. When substituted into this line:
```
calculationCounter = (calculationCounter + 1) % ARRAY_SIZE;
```
it became
```
calculationCounter = (calculationCounter + 1) % 1250 / 50;
```
which set `calculationCounter` to 0, which meant we only ever considered one spot in the array. This is why RPM was temporarily broken. 
The solution was just to calculate the macro beforehand: `#define ARRAY_SIZE = 25`